### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP (Model Context Protocol) server provides integration between the Hunter API and any LLM provider supporting the MCP protocol (e.g., Claude for Desktop), allowing you to interact with the Hunter B2B data using natural language.
 
+<a href="https://glama.ai/mcp/servers/@hunter-io/hunter-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hunter-io/hunter-mcp/badge" alt="Hunter Server MCP server" />
+</a>
+
 ## ✨ Features
 - Use Hunter API endpoints using natural language
 - Get B2B data about People and Companies


### PR DESCRIPTION
This PR adds a badge for the [Hunter MCP Server](https://glama.ai/mcp/servers/@hunter-io/hunter-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hunter-io/hunter-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hunter-io/hunter-mcp/badge" alt="Hunter Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.